### PR TITLE
Sanitize file names to align with npm pack, fixes #5

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -90,7 +90,12 @@ NPM.prototype.listDependencies = function listDependencies(obj, name, prefix) {
         };
     }
 
-    var fileName = name + '-' + newObj.version + '.tgz';
+    // npm pack will remove @ symbols from the name.
+    var santitizedName = name.replace(/[@]/, '');
+    // slashes are converted into dashes by npm pack
+    santitizedName = santitizedName.replace(/[/]/, '-');
+
+    var fileName = santitizedName + '-' + newObj.version + '.tgz';
     var filePath = path.join($this._fullTargetPath, fileName);
     var pathParts = [$this._target, fileName];
     if(prefix) {


### PR DESCRIPTION
npm will strip certain characters from the file name and replaces slashes with dashes when running pack. This results in the resolved url currently not being correct.